### PR TITLE
feat: Export mode + single combined export (v3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.2] - August 9, 2025
+
+- **Feature:** Added Export mode selector (Multiple files or Single combined file)
+  - New option in the popup to choose between downloading one XLSX per order or a single XLSX containing all selected orders
+  - Combined export is processed sequentially in one background tab for reliability
+  - Uses ExcelJS in the popup to generate a single workbook with all items
+- **Enhancement:** Content script now supports structured data retrieval (no download) to power combined export
+- **Note:** Existing multiple-file download flow remains unchanged
+
 ## [3.1] - March 25, 2025
 
 - **Enhancement:** Added order description tooltip functionality

--- a/popup.css
+++ b/popup.css
@@ -62,6 +62,15 @@ body {
   font-size: 12px;
 }
 
+.input-group select {
+  width: 100%;
+  padding: 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 12px;
+  background: white;
+}
+
 .input-group input:focus {
   outline: none;
   border-color: var(--primary);

--- a/popup.html
+++ b/popup.html
@@ -4,6 +4,7 @@
 <head>
     <title>Walmart Invoice Exporter</title>
     <link rel="stylesheet" href="popup.css">
+    <script src="exceljs.bare.min.js"></script>
 </head>
 
 <body>
@@ -38,6 +39,13 @@
         <div class="input-group">
             <label for="pageLimit">Number of pages to crawl (0 = unlimited)</label>
             <input type="number" id="pageLimit" min="0" value="0">
+        </div>
+        <div class="input-group">
+            <label for="exportMode">Export mode</label>
+            <select id="exportMode">
+                <option value="multiple">Multiple files (one per order)</option>
+                <option value="single">Single file (all items)</option>
+            </select>
         </div>
         <div class="button-group">
             <button id="startCollection" class="btn btn-primary">


### PR DESCRIPTION
- Adds Export mode selector (Multiple files vs Single combined file).
- Implements single combined export in popup using ExcelJS; sequential single-tab flow for reliability.
- Content script: adds getOrderData and refactors scraping into a reusable function.
- Keeps existing multi-file download behavior unchanged.
- Updates CHANGELOG to v3.2.

Feel free to change whatever you want. I just downloaded all of my items ever ordered using this new feature, which was super helpful to feed into AI to analyze my shopping/spending habits. 🚀