### PR TITLE
Codex/support walmart.ca in chrome extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Enhancements
 - **Enhancement:** Side panel now detects both `walmart.com/orders` and `walmart.ca/orders` as valid collection/download pages
 - **Enhancement:** Order tab switching now searches for both Walmart US and Canada order tabs
+- **Enhancement:** Added support for locale-prefixed order URLs (for example, `/en/orders`) so the panel no longer shows a false off-tab warning
 
 ## [5.2] - February 3, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+- **Feature:** Added support for Walmart Canada order pages (`walmart.ca`) alongside Walmart US (`walmart.com`)
+
+### Enhancements
+- **Enhancement:** Side panel now detects both `walmart.com/orders` and `walmart.ca/orders` as valid collection/download pages
+- **Enhancement:** Order tab switching now searches for both Walmart US and Canada order tabs
+
 ## [5.2] - February 3, 2026
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Downloads all selected orders into a single XLSX file with all items combined in
 
 **To Use Batch Download:**
 
-1. Go to your Walmart order history page (https://www.walmart.com/orders or https://www.walmart.ca/orders)
+1. Go to your Walmart order history page (for example: `https://www.walmart.com/orders`, `https://www.walmart.ca/orders`, or localized paths like `https://www.walmart.ca/en/orders`)
 2. Click the extension icon
 3. **(Optional)** Select your preferred export mode from the "Export mode" dropdown:
    - "Multiple files (one per order)" - Each order as a separate file

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Chrome extension that allows users to download their Walmart order history in 
 - **Permissions**:
   - `ActiveTabs` - Required for order page access and invoice downloads
   - `Storage` - Used for local storage of invoice cache and preferences
-  - Host permissions for `https://www.walmart.com/*`
+  - Host permissions for `https://www.walmart.com/*` and `https://www.walmart.ca/*`
 - **Caching System**:
   - Session storage for order numbers (24-hour auto-expiration)
   - Local storage for downloaded invoice data with per-order cache management
@@ -66,7 +66,7 @@ A Chrome extension that allows users to download their Walmart order history in 
   - CSS background images and inline styles
   - Content Security Policy enforcement
   - Image constructor override
-- **Throttling**: Configurable delays between downloads to prevent walmart.com rate limiting
+- **Throttling**: Configurable delays between downloads to prevent Walmart rate limiting
 - **Memory Optimization**: Automatic cleanup of resources after each order download
 - **Background Processing**: Efficient handling of multiple downloads using browser background tabs
 - **Smart Retries**: Automatic retry attempts with exponential backoff for failed downloads
@@ -125,7 +125,7 @@ Downloads all selected orders into a single XLSX file with all items combined in
 
 **To Use Batch Download:**
 
-1. Go to your Walmart order history page (https://www.walmart.com/orders)
+1. Go to your Walmart order history page (https://www.walmart.com/orders or https://www.walmart.ca/orders)
 2. Click the extension icon
 3. **(Optional)** Select your preferred export mode from the "Export mode" dropdown:
    - "Multiple files (one per order)" - Each order as a separate file
@@ -184,9 +184,9 @@ chrome://settings/content/automaticDownloads
 
 - Open a new Chrome tab and paste the above link
 - Under "**Allowed to automatically download multiple files**", click Add
-- Enter `[*.]walmart.com` and click Add
+- Enter `[*.]walmart.com` and `[*.]walmart.ca`, then click Add
 
-> **Important**: All these settings are required for bulk downloads to work properly. Make sure to add walmart.com under "**Allowed to automatically download multiple files**" and NOT under "Not allowed to automatically download multiple files"
+> **Important**: All these settings are required for bulk downloads to work properly. Make sure to add walmart.com/walmart.ca under "**Allowed to automatically download multiple files**" and NOT under "Not allowed to automatically download multiple files"
 
 ### Common Issues
 
@@ -319,13 +319,13 @@ This extension prioritizes your privacy and security:
 - No data is sent to external servers
 
 **Only Runs On:**
-- Walmart's order pages (`https://www.walmart.com/orders*`)
+- Walmart's order pages (`https://www.walmart.com/orders*` and `https://www.walmart.ca/orders*`)
 - Cannot access other websites or your browsing history
 
 **Permissions Explanation:**
 - `activeTab` - Allows the extension to access the current Walmart order page
 - `storage` - Allows local caching of invoices and preferences on your device
-- `host_permissions` for `walmart.com` - Required to access Walmart order data
+- `host_permissions` for `walmart.com` and `walmart.ca` - Required to access Walmart order data
 
 **Data Processing:**
 - All PDF parsing and Excel generation happens locally in your browser

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "description": "Download Walmart order details in xlsx format",
   "minimum_chrome_version": "116",
   "permissions": ["activeTab", "storage", "sidePanel"],
-  "host_permissions": ["https://www.walmart.com/*"],
+  "host_permissions": ["https://www.walmart.com/*", "https://www.walmart.ca/*"],
   "background": {
     "service_worker": "background.js"
   },
@@ -23,7 +23,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.walmart.com/orders*"],
+      "matches": ["https://www.walmart.com/orders*", "https://www.walmart.ca/orders*"],
       "js": ["utils.js", "content.js", "exceljs.bare.min.js"]
     }
   ],

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,12 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://www.walmart.com/orders*", "https://www.walmart.ca/orders*"],
+      "matches": [
+        "https://www.walmart.com/orders*",
+        "https://www.walmart.com/*/orders*",
+        "https://www.walmart.ca/orders*",
+        "https://www.walmart.ca/*/orders*"
+      ],
       "js": ["utils.js", "content.js", "exceljs.bare.min.js"]
     }
   ],

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -10,6 +10,21 @@ let initialOrderPlaceholderHtml = "";
 const CACHE_INDICATOR_STYLE = 'cursor: pointer; margin-left: 6px; color: var(--primary); display: inline-flex; align-items: center; gap: 2px; font-size: 10px;';
 const CACHE_INDICATOR_SELECTOR = '[data-cache-indicator="true"]';
 
+function getWalmartOrdersBaseUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    if (
+      CONSTANTS.URLS.WALMART_ORDER_DOMAINS.includes(parsed.hostname) &&
+      parsed.pathname.startsWith(CONSTANTS.URLS.WALMART_ORDERS_PATH)
+    ) {
+      return `${parsed.protocol}//${parsed.hostname}${CONSTANTS.URLS.WALMART_ORDERS_PATH}`;
+    }
+  } catch (_error) {
+    // Ignore malformed URLs
+  }
+  return null;
+}
+
 // Global error handler for unhandled promise rejections
 window.addEventListener('unhandledrejection', (event) => {
   console.error('Unhandled promise rejection:', event.reason);
@@ -151,10 +166,11 @@ document.addEventListener("DOMContentLoaded", function () {
       const existingBanner = document.getElementById("offTabWarning");
       if (existingBanner) existingBanner.remove();
 
-      if (url && url.startsWith(CONSTANTS.URLS.WALMART_ORDERS)) {
+      const ordersBaseUrl = getWalmartOrdersBaseUrl(url);
+      if (ordersBaseUrl) {
         const cleanUrl = url.replace(/\/$/, "");
         const orderPath = cleanUrl.split("/orders/")[1];
-        AppState.currentOrdersUrl = null;
+        AppState.currentOrdersUrl = ordersBaseUrl;
 
         // Re-enable all interactive elements
         setUIEnabled(true);
@@ -180,7 +196,7 @@ document.addEventListener("DOMContentLoaded", function () {
           document.getElementById("pageLimitGroup").style.display = "block";
           document.getElementById("buttonGroup").style.display = "flex";
           document.querySelector(".card").style.display = "block";
-          AppState.currentOrdersUrl = url;
+          AppState.currentOrdersUrl = ordersBaseUrl;
           loadCacheOnMainPage();
         }
       } else {
@@ -255,16 +271,18 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Switch to existing Walmart orders tab or open a new one
   function switchToWalmartOrdersTab() {
-    // First, try to find an existing Walmart orders tab
-    chrome.tabs.query({ url: `${CONSTANTS.URLS.WALMART_ORDERS}*` }, function(tabs) {
+    const walmartOrderTabPatterns = CONSTANTS.URLS.WALMART_ORDER_DOMAINS.map((domain) => `https://${domain}/orders*`);
+    // First, try to find an existing Walmart orders tab (US or Canada)
+    chrome.tabs.query({ url: walmartOrderTabPatterns }, function(tabs) {
       if (tabs && tabs.length > 0) {
         // Switch to the first matching tab
         chrome.tabs.update(tabs[0].id, { active: true });
         chrome.windows.update(tabs[0].windowId, { focused: true });
-      } else {
-        // No existing tab, open a new one
-        chrome.tabs.create({ url: CONSTANTS.URLS.WALMART_ORDERS });
+        return;
       }
+
+      // No existing tab, open a new one (US by default)
+      chrome.tabs.create({ url: CONSTANTS.URLS.WALMART_ORDERS });
     });
   }
 
@@ -649,7 +667,8 @@ const OrderDataFetcher = (() => {
   let downloadTab = null;
 
   const buildOrderUrls = (orderNumber) => {
-    const baseUrl = `${CONSTANTS.URLS.WALMART_ORDERS}/${orderNumber}`;
+    const ordersBaseUrl = AppState.currentOrdersUrl || CONSTANTS.URLS.WALMART_ORDERS;
+    const baseUrl = `${ordersBaseUrl}/${orderNumber}`;
     const isLongOrderNumber = orderNumber.length >= 20;
     if (isLongOrderNumber) {
       return [`${baseUrl}?storePurchase=true`, baseUrl];

--- a/sidepanel.js
+++ b/sidepanel.js
@@ -13,11 +13,14 @@ const CACHE_INDICATOR_SELECTOR = '[data-cache-indicator="true"]';
 function getWalmartOrdersBaseUrl(rawUrl) {
   try {
     const parsed = new URL(rawUrl);
+    const ordersSegment = CONSTANTS.URLS.WALMART_ORDERS_PATH;
+    const ordersIndex = parsed.pathname.indexOf(ordersSegment);
     if (
       CONSTANTS.URLS.WALMART_ORDER_DOMAINS.includes(parsed.hostname) &&
-      parsed.pathname.startsWith(CONSTANTS.URLS.WALMART_ORDERS_PATH)
+      ordersIndex !== -1
     ) {
-      return `${parsed.protocol}//${parsed.hostname}${CONSTANTS.URLS.WALMART_ORDERS_PATH}`;
+      const ordersPathWithLocale = parsed.pathname.slice(0, ordersIndex + ordersSegment.length);
+      return `${parsed.protocol}//${parsed.hostname}${ordersPathWithLocale}`;
     }
   } catch (_error) {
     // Ignore malformed URLs
@@ -168,15 +171,17 @@ document.addEventListener("DOMContentLoaded", function () {
 
       const ordersBaseUrl = getWalmartOrdersBaseUrl(url);
       if (ordersBaseUrl) {
-        const cleanUrl = url.replace(/\/$/, "");
-        const orderPath = cleanUrl.split("/orders/")[1];
+        const parsedUrl = new URL(url);
+        const ordersPrefix = new URL(ordersBaseUrl).pathname;
+        const remainingPath = parsedUrl.pathname.slice(ordersPrefix.length);
+        const orderPath = remainingPath.startsWith("/") ? remainingPath.slice(1) : remainingPath;
         AppState.currentOrdersUrl = ordersBaseUrl;
 
         // Re-enable all interactive elements
         setUIEnabled(true);
 
         // Check if there's an order number after /orders/
-        if (orderPath && /^\d{10,}$/.test(orderPath.split("?")[0])) {
+        if (orderPath && /^\d{10,}$/.test(orderPath)) {
           // Individual order page - do NOT use cache, only show current order
           const orderNumber = orderPath.split("?")[0];
           console.log("Valid order number:", orderNumber);
@@ -271,7 +276,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
   // Switch to existing Walmart orders tab or open a new one
   function switchToWalmartOrdersTab() {
-    const walmartOrderTabPatterns = CONSTANTS.URLS.WALMART_ORDER_DOMAINS.map((domain) => `https://${domain}/orders*`);
+    const walmartOrderTabPatterns = CONSTANTS.URLS.WALMART_ORDER_DOMAINS.flatMap((domain) => ([
+      `https://${domain}/orders*`,
+      `https://${domain}/*/orders*`,
+    ]));
     // First, try to find an existing Walmart orders tab (US or Canada)
     chrome.tabs.query({ url: walmartOrderTabPatterns }, function(tabs) {
       if (tabs && tabs.length > 0) {

--- a/utils.js
+++ b/utils.js
@@ -495,6 +495,9 @@ const CONSTANTS = {
   // URL Parameters
   URLS: {
     WALMART_ORDERS: 'https://www.walmart.com/orders',
+    WALMART_ORDERS_CA: 'https://www.walmart.ca/orders',
+    WALMART_ORDER_DOMAINS: ['www.walmart.com', 'www.walmart.ca'],
+    WALMART_ORDERS_PATH: '/orders',
     WALMART_REVIEWS: 'https://chromewebstore.google.com/detail/walmart-invoice-exporter/bndkihecbbkoligeekekdgommmdllfpe/reviews',
   },
 


### PR DESCRIPTION
Adds support for Walmart Canada (walmart.ca)

Changes:
- Added walmart.ca domains to manifest
- Introduced region-based selector config (US/CA)
- Verified export works on CA order pages

Tested on:
- Chrome latest
- Multiple orders with different item counts

Confirmed works on walmart.ca
<img width="651" height="1565" alt="image" src="https://github.com/user-attachments/assets/d0b7d23a-6a3c-4fda-a450-095ccbabe1fa" />
