### PR TITLE
Fix item extraction: read from product cards after Walmart removed print markup (fixes #14)

### DIFF
--- a/content.js
+++ b/content.js
@@ -175,6 +175,42 @@ async function waitForElement(
   throw new Error(`Element ${selector} not found after ${timeout}ms`);
 }
 
+// Wait until the order detail page has rendered its product cards before
+// scraping. The combined-export flow loads each order in a background tab, which
+// browsers throttle, so a scrape can otherwise run against a still-blank page and
+// yield empty rows. Poll until at least one card has a name, or give up after the
+// timeout.
+async function waitForOrderItems(
+  timeout = CONSTANTS.TIMING.COLLECTION_TIMEOUT,
+  pollInterval = CONSTANTS.TIMING.ELEMENT_POLL_INTERVAL
+) {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeout) {
+    const named = Array.from(
+      document.querySelectorAll(CONSTANTS.SELECTORS.ITEM_STACK)
+    ).some((card) => card.querySelector(CONSTANTS.SELECTORS.CARD_NAME)?.innerText?.trim());
+    if (named) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollInterval));
+  }
+  console.warn("waitForOrderItems: no populated item cards before timeout");
+  return false;
+}
+
+// Pull the price actually charged for a line item out of its card. The card's
+// price block mixes several dollar amounts - per-item savings ("$3.98 from
+// savings"), the discounted price, and the struck-through "Was" price - so we
+// strip the savings and "Was" amounts first, then take the remaining price.
+function extractCardPrice(card) {
+  const priceEl = card.querySelector(CONSTANTS.SELECTORS.CARD_PRICE) || card;
+  const text = (priceEl.innerText || "")
+    .replace(/\$[\d,.]+\s*from\s+[a-z ]*?(savings|discount)/gi, "")
+    .replace(/Was\s*\$[\d,.]+/gi, "");
+  const match = text.match(/\$([\d,]+\.\d{2})/);
+  return match ? match[1].replace(/,/g, "") : "";
+}
+
 const withImageBlocking = (handler) => async (request) => {
   ImageBlocker.aggressive();
   return handler(request);
@@ -185,12 +221,16 @@ const MessageHandlers = {
   [CONSTANTS.MESSAGES.CLICK_NEXT_BUTTON]: withImageBlocking(handleClickNextButton),
   [CONSTANTS.MESSAGES.BLOCK_IMAGES]: withImageBlocking(async () => ({ success: true })),
   [CONSTANTS.MESSAGES.DOWNLOAD_XLSX]: withImageBlocking(async () => {
+    await waitForOrderItems();
     const data = scrapeOrderData();
     // Convert the order details to an XLSX file using the shared convertToXlsx function
     convertToXlsx(data, ExcelJS, { mode: 'single' });
     return { data };
   }),
-  [CONSTANTS.MESSAGES.GET_ORDER_DATA]: withImageBlocking(async () => ({ data: scrapeOrderData() })),
+  [CONSTANTS.MESSAGES.GET_ORDER_DATA]: withImageBlocking(async () => {
+    await waitForOrderItems();
+    return { data: scrapeOrderData() };
+  }),
 };
 
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
@@ -218,37 +258,38 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 function scrapeOrderData() {
   const orderItems = [];
 
-  // Query the hidden print items list which contains reliable product data
-  // This list is always present in the DOM (hidden via .dn class) and is populated on page load.
-  // It provides a cleaner data structure compared to the complex interactive UI.
-  const printItemsList = document.querySelectorAll(CONSTANTS.SELECTORS.PRINT_ITEMS);
+  // Read line items straight from the visible product cards. Walmart removed the
+  // hidden ".dn.print-items-list" print markup this used to scrape, which is why
+  // name, price, and the product link all stopped populating (the link, in
+  // particular, came out "N/A" because the old code matched a print-markup name
+  // against a card name by exact string equality across two separately-rendered
+  // DOM trees). Each card now carries the product's name, href (with the item id
+  // in its /ip/<slug>/<itemId> URL), quantity, and price together, so there is no
+  // fragile cross-tree matching.
+  const cards = document.querySelectorAll(CONSTANTS.SELECTORS.ITEM_STACK);
 
-  printItemsList.forEach((item) => {
-    const productName = item.querySelector(CONSTANTS.SELECTORS.PRINT_ITEM_NAME)?.innerText;
-    // Fall back to default delivery label if status element not found
-    const deliveryStatus = item.querySelector(CONSTANTS.SELECTORS.PRINT_BILL_TYPE)?.innerText || CONSTANTS.TEXT.DELIVERY_LABEL;
-    const quantity = item.querySelector(CONSTANTS.SELECTORS.PRINT_BILL_QTY)?.innerText;
-    const price = item.querySelector(CONSTANTS.SELECTORS.PRINT_BILL_PRICE)?.innerText;
-
-    // Find the corresponding visible item to get the product link
-    let productLink = "N/A";
-    const visibleItems = document.querySelectorAll(CONSTANTS.SELECTORS.VISIBLE_ITEMS);
-    for (const visibleItem of visibleItems) {
-      if (visibleItem?.innerText.trim() === (productName || '').trim()) {
-        const linkElement = visibleItem.closest(CONSTANTS.SELECTORS.ITEM_STACK)?.querySelector(CONSTANTS.SELECTORS.PRODUCT_LINK);
-        if (linkElement) {
-          productLink = linkElement.href;
-          break;
-        }
-      }
+  cards.forEach((card) => {
+    const productName = card.querySelector(CONSTANTS.SELECTORS.CARD_NAME)?.innerText.trim();
+    if (!productName) {
+      return; // skip stray cards that carry no product
     }
+
+    const linkEl = card.querySelector(CONSTANTS.SELECTORS.PRODUCT_LINK);
+    const productLink = linkEl?.href || "N/A";
+    if (productLink === "N/A") {
+      console.warn("No product link found for:", productName);
+    }
+
+    const qtyMatch = (card.innerText || "").match(/Qty\s*(\d+)/i);
 
     orderItems.push({
       productName,
       productLink,
-      deliveryStatus,
-      quantity,
-      price,
+      // Per-item delivery status lived in the removed print markup; the live page
+      // only exposes delivery status at the order level, so default it here.
+      deliveryStatus: CONSTANTS.TEXT.DELIVERY_LABEL,
+      quantity: qtyMatch ? qtyMatch[1] : "1",
+      price: extractCardPrice(card),
     });
   });
 

--- a/utils.js
+++ b/utils.js
@@ -429,7 +429,11 @@ const CONSTANTS = {
     PRINT_BILL_PRICE: '.print-bill-price .w_U9_0.w_sD6D.w_QcqU',
     VISIBLE_ITEMS: '[data-testid="itemtile-stack"] [data-testid="productName"] span',
     ITEM_STACK: '[data-testid="itemtile-stack"]',
-    PRODUCT_LINK: 'a[link-identifier="itemClick"]',
+    CARD_NAME: '[data-testid="productName"]',
+    CARD_PRICE: '[data-testid="line-price"]',
+    // Match the product anchor by its /ip/<slug>/<itemId> href so it survives
+    // Walmart renaming the old link-identifier="itemClick" attribute.
+    PRODUCT_LINK: 'a[href*="/ip/"]',
 
     PRINT_BILL_GROUP: '.print-bill-group',
     PRINT_ITEM_ROW: '.dn.print-items-list > .flex.justify-between',


### PR DESCRIPTION
## Problem

v6.2 runs but no longer populates product **name**, **price**, **quantity**, or the **product link** (the link exports as the literal string `N/A`). Reported in #14.

## Root cause

Two issues, one underlying:

1. **Walmart removed the hidden print markup.** `scrapeOrderData()` read line items from `.dn.print-items-list`, which no longer exists on the order detail page (`document.querySelectorAll('.dn.print-items-list').length === 0`). With nothing to iterate, every per-item field came back empty.
2. **The product link was matched fragilely.** Even when names populated, the link was found by comparing the print-markup product name to the visible card name via exact `innerText` string equality, across two independently-rendered DOM trees. Any whitespace or line-wrap difference failed silently and fell back to `"N/A"`.

## Fix

Read each line item straight from the visible product card (`[data-testid="itemtile-stack"]`), which carries the name, the product href (with the item id in its `/ip/<slug>/<itemId>` URL), quantity, and price all in one place. This removes the cross-tree name matching entirely.

- Product anchor matched by `a[href*="/ip/"]` so it survives the renamed `link-identifier="itemClick"` attribute.
- Price pulled from `[data-testid="line-price"]`, stripping per-item savings and the struck-through "Was" amount so the charged price is what is captured.
- Added `waitForOrderItems()`, awaited before scraping, so the combined-export flow (which loads each order in a throttled background tab) doesn't scrape a still-blank page.

Scoped deliberately to the extraction fix. Only `content.js` and `utils.js` change.

## Testing

Verified against a real, logged-in Walmart account: ran both single-order and the combined multi-order export across a full order history (200+ line items, ~100 orders). Name, quantity, price, and a real `/ip/.../<itemId>` product link now populate on every row, where before the run produced blank fields and `N/A` links.

Order-level totals (Subtotal / Order Total) use separate `print-bill-*` selectors that were also removed in the same Walmart redesign and are out of scope here; this PR restores the per-item line data, which is what #14 reports.
