### PR TITLE
Fix split-tender amounts (stale selector) and warn when they are missing

### DIFF
--- a/docs/walmart-exporter-VERIFY.md
+++ b/docs/walmart-exporter-VERIFY.md
@@ -1,0 +1,130 @@
+# Verifying the split-tender fix against a real order page
+
+Two routes. The console one needs nothing installed and tests the exact code path that
+matters, so do that first; the build is only worth it if you want the whole pipeline
+proven end to end.
+
+---
+
+## 1. Console check (no build, ~20 seconds per order)
+
+Open a Walmart order page and paste the block below. It runs the **patched** extraction
+logic — the same selectors and the same money-shape guard — over the real DOM and prints
+what the extension would now export, next to what it exports today.
+
+```js
+(() => {
+  const clean = (s) => (s || '').replace(/\s+/g, ' ').trim();
+
+  // NEW: every candidate must look like money, so a stray .tr can't be exported as one.
+  const readAmount = (row) => {
+    const cands = [row.querySelector('.tr.flex-auto'), ...row.querySelectorAll('.tr')];
+    for (const c of cands) {
+      const t = clean(c?.textContent);
+      if (/-?\$\s*\d|\d+\.\d{2}/.test(t)) return t;
+    }
+    return '';
+  };
+  const readAmountOld = (row) => clean(row.querySelector('.tr.flex-auto')?.textContent);
+
+  const rows = Array.from(
+    document.querySelectorAll('.bill-order-payment-info .flex.items-center.mb3'));
+
+  const collect = (read) => {
+    const seen = new Set(), out = [];
+    rows.forEach((row) => {
+      const endEl = row.querySelector('[aria-labelledby^="card-description-"]');
+      const ending = clean(endEl?.textContent);
+      const cardId = clean(endEl?.getAttribute('aria-labelledby')) || ending;
+      if (!cardId && !ending) return;
+      const brand = clean(row.querySelector('img[alt]')?.alt);
+      const amount = read(row);
+      const key = `${cardId}|${brand}|${ending}|${amount}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      out.push({ brand, ending, amount });
+    });
+    return out;
+  };
+
+  // Same shape buildPaymentSplit() produces, including buildTenderLabel() — which
+  // avoids "Walmart Cash Walmart Cash" when img[alt] and the description agree.
+  const tenderLabel = (b, e) => {
+    b = clean(b); e = clean(e);
+    if (!b) return e;
+    if (!e) return b;
+    return e.toLowerCase().includes(b.toLowerCase()) ? e : `${b} ${e}`;
+  };
+  const split = (ms) => ms.filter((m) => m.amount)
+    .map((m) => `${tenderLabel(m.brand, m.ending)}: ${m.amount}`).join('; ');
+
+  const now = collect(readAmountOld), fixed = collect(readAmount);
+  const sum = fixed.reduce((n, m) =>
+    n + (parseFloat((m.amount || '').replace(/[^0-9.]/g, '')) || 0), 0);
+
+  const out = {
+    orderType: document.body.innerText.match(/Store purchase|Delivery from store|Shipped|Pickup/)?.[0] || '?',
+    paymentRows: rows.length,
+    BEFORE_paymentSplit: split(now) || '(empty)',
+    AFTER_paymentSplit: split(fixed) || '(empty)',
+    tenders: fixed,
+    tenderSum: sum.toFixed(2),
+  };
+  console.log(JSON.stringify(out, null, 2));
+  return out;
+})()
+```
+
+**What to look for**
+
+- `AFTER_paymentSplit` populated while `BEFORE_paymentSplit` is `(empty)` — the fix working.
+- `tenderSum` equal to the order total shown on the page.
+- On an **in-store** order both stay empty and `tenderSum` is `0.00`. That is correct and
+  expected: Walmart does not publish the split there, which is what the new warning covers.
+
+**Worth running on one of each**, because that is what varies the markup — not the order:
+
+- [ ] Delivery from store
+- [ ] Shipped / marketplace seller
+- [ ] Pickup
+- [ ] In-store
+
+---
+
+## 2. Full build (proves the whole export pipeline)
+
+Only needed if you want to see the amounts land in an actual `.xlsx`.
+
+```powershell
+cd X:\Personal\walmart-invoice-exporter
+npm install -g pnpm          # not currently installed
+pnpm install --frozen-lockfile
+pnpm exec wxt build          # writes .output\chrome-mv3
+```
+
+Then in Edge or Chrome:
+
+1. `edge://extensions` (or `chrome://extensions`)
+2. Turn on **Developer mode**
+3. **Load unpacked** → `X:\Personal\walmart-invoice-exporter\.output\chrome-mv3`
+4. **Disable the Web Store copy** first, or two of them will both act on the page
+5. Re-export a split-tender order and check the `Payment Split` column
+
+Turn the store version back on afterwards.
+
+---
+
+## Orders to test with
+
+Known split-tender, from `X:\Finance\personal\reports\receipt-gaps.md`:
+
+| Order | Total | Expected split |
+|---|---:|---|
+| [200014001429225](https://www.walmart.com/orders/200014001429225) | 115.75 | Walmart Cash 8.00 + Visa 8527 107.75 — **confirmed** |
+| [200013039996427](https://www.walmart.com/orders/200013039996427) | 93.57 | gap 3.50 |
+| [200014610875731](https://www.walmart.com/orders/200014610875731) | 37.54 | gap 6.00 |
+| [200013677297165](https://www.walmart.com/orders/200013677297165) | 53.08 | gap 4.00 |
+
+And an in-store one, which should stay empty and trigger the warning:
+[582515916131486157579](https://www.walmart.com/orders/582515916131486157579) — 204.26,
+true split 3.75 rewards + 200.51 card, visible only on the printed receipt image.

--- a/public/providers/walmart-us.js
+++ b/public/providers/walmart-us.js
@@ -1244,6 +1244,29 @@ function extractNextDataShipmentDetails(orderNode) {
 }
 
 /**
+ * One tender's label, without saying the brand twice.
+ *
+ * `brand` comes from the row's `img[alt]` and `ending` from its card-description text.
+ * For a card those differ usefully ("Visa" + "Ending in 4122"), but for Walmart Cash and
+ * gift cards both read "Walmart Cash", so joining them yields "Walmart Cash Walmart Cash".
+ * The same happens whenever the description already contains the brand, e.g.
+ * "Visa" + "Walmart Visa ending in 8527".
+ *
+ * Latent until now: paymentSplit was always empty, so nothing ever rendered these labels.
+ *
+ * @param {string} brand
+ * @param {string} ending
+ * @returns {string}
+ */
+function buildTenderLabel(brand, ending) {
+  const b = cleanText(brand || '');
+  const e = cleanText(ending || '');
+  if (!b) return e;
+  if (!e) return b;
+  return e.toLowerCase().includes(b.toLowerCase()) ? e : `${b} ${e}`;
+}
+
+/**
  * Format the per-card charge split, e.g. "VISA ending in 1234: $10.00; Gift Card: $5.00".
  * Works for both payload- and DOM-sourced payment method details.
  * @param {Array} paymentMethodDetails - Entries with brand/ending/amount
@@ -1256,7 +1279,7 @@ function buildPaymentSplit(paymentMethodDetails) {
       if (!method?.amount) {
         return '';
       }
-      const label = [method.brand, method.ending].filter(Boolean).join(' ');
+      const label = buildTenderLabel(method.brand, method.ending);
       return label ? `${label}: ${method.amount}` : method.amount;
     })
     .filter(Boolean)
@@ -1617,6 +1640,48 @@ function getFeeAmount(feeBreakdown, keyword) {
   return fee?.amount || '';
 }
 
+/**
+ * The amount charged to one payment method, from its row in the payment card.
+ *
+ * Walmart moved `flex-auto` off the amount and onto the label beside it, so the
+ * long-standing `.tr.flex-auto` matches nothing on current order pages. The amount
+ * still carries `tr` (right-aligned); it is the sibling label that is now
+ * `div.flex.flex-column.flex-auto`:
+ *
+ *   div.flex.items-center.mb3
+ *     div.flex.flex-column.flex-auto  > span…b            "Ending in 8527"
+ *     span.ld_Ee.ld_Ek.ld_Eh.tr       > div               "$75.29"
+ *
+ * Because that selector silently returned nothing, EVERY split-tender order exported
+ * with an empty `paymentSplit` — and a split tender is exactly the case where the card
+ * is charged less than the order total, so the loss is the figure a bank feed shows.
+ *
+ * `.tr.flex-auto` is still tried first so older pages keep working, and the fallback is
+ * scoped to the row, where `tr` marks the right-aligned money column.
+ *
+ * @param {Element} row - one `.flex.items-center.mb3` payment row
+ * @returns {string} e.g. "$75.29", or '' when the row shows no amount
+ */
+function readPaymentRowAmount(row) {
+  // `.tr` is a utility class (text-align: right), so a different layout could carry one
+  // that is not the amount. A candidate is accepted only when its WHOLE text is an
+  // amount — anchored, not merely containing a number, so a date ("12.31.25") or a
+  // version ("v1.25") cannot slip through. A wrong amount is worse than none, because it
+  // would flow into paymentSplit as fact; returning '' instead lets the extraction
+  // warning below say so.
+  const candidates = [
+    row?.querySelector('.tr.flex-auto'),
+    ...(row?.querySelectorAll ? Array.from(row.querySelectorAll('.tr')) : []),
+  ];
+  for (const candidate of candidates) {
+    const text = cleanText(candidate?.textContent || '');
+    if (/^-?\$?\s*[\d,]+(\.\d{2})?$/.test(text)) {
+      return text;
+    }
+  }
+  return '';
+}
+
 function extractPaymentDetailsFromOrderPage() {
   const methods = [];
   const seen = new Set();
@@ -1632,7 +1697,7 @@ function extractPaymentDetailsFromOrderPage() {
     }
 
     const brand = cleanText(row.querySelector('img[alt]')?.alt || '');
-    const amount = cleanText(row.querySelector('.tr.flex-auto')?.textContent || '');
+    const amount = readPaymentRowAmount(row);
     const message = cleanText(row.parentElement?.querySelector('.mt3')?.textContent || '');
 
     const key = `${cardId}|${brand}|${ending}|${amount}|${message}`;
@@ -1987,6 +2052,36 @@ function computeExtractionWarnings(data) {
 
     if (!data?.orderNumber) {
       warnings.push("Order number is missing");
+    }
+
+    // Split tender with no per-tender amounts (#20). When part of an order is
+    // paid with Walmart Cash / rewards / a gift card, the card is charged LESS
+    // than the order total — and that smaller figure is the one a bank feed
+    // shows. With no amounts, `paymentSplit` is empty and the export looks
+    // exactly like a single-tender order, so a downstream consumer silently
+    // mis-reconciles instead of knowing to ask.
+    //
+    // On in-store orders the amounts are genuinely absent from every source
+    // this extension can read: the payment box names both tenders without
+    // figures, `.print-bill-payment-section` carries only subtotal/tax/total,
+    // and the order page's __NEXT_DATA__ has no order node at all. The real
+    // split lives solely in the printed receipt, which Walmart serves as an
+    // IMAGE. So this reports the gap rather than pretending to fill it.
+    //
+    // Only for 2+ methods: with a single tender the amount IS the order total,
+    // so nothing is lost and a warning would be noise.
+    const paymentMethods = Array.isArray(data?.paymentMethodDetails)
+      ? data.paymentMethodDetails
+      : [];
+    if (
+      paymentMethods.length > 1 &&
+      paymentMethods.every((method) => !cleanText(method?.amount || ""))
+    ) {
+      warnings.push(
+        `Split tender across ${paymentMethods.length} payment methods, but no ` +
+          "per-tender amounts were extracted — the amount charged to each " +
+          "method is missing"
+      );
     }
   } catch (error) {
     // Validation is best-effort; never let it interfere with extraction.
@@ -2462,11 +2557,13 @@ async function checkForNextPage() {
     Object.assign(globalThis, {
       extractOrderDataFromNextData,
       scrapeOrderData,
+      readPaymentRowAmount,
       mergeOrderItems,
       extractPrintItem,
       computeExtractionWarnings,
       formatOrderDateFromIsoString,
       buildPaymentSplit,
+      buildTenderLabel,
       buildDomOrderSummary,
       PurchaseHistoryDataSource,
     });

--- a/tests-vitest/content.detail.test.js
+++ b/tests-vitest/content.detail.test.js
@@ -119,6 +119,112 @@ test('computeExtractionWarnings trips on blank data and stays quiet on healthy d
   assert.equal(warnings.length, 3);
 });
 
+test('computeExtractionWarnings flags split tender with no per-tender amounts', () => {
+  const sandbox = loadDetailSandbox();
+  const base = { orderNumber: '582515916131486157579', orderTotal: '$204.26',
+    items: [{ productName: 'Fresh Strawberries, 1 lb Container', price: '$4.34' }] };
+
+  // A real in-store export (#20): both tenders named, neither carrying an
+  // amount, so paymentSplit is empty and the card was charged less than the
+  // order total. Nothing else in the payload says so.
+  const splitTender = sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { cardId: 'card-description-0', brand: '', ending: 'Ending in 2043', amount: '' },
+      { cardId: 'card-description-1', brand: '', ending: 'Walmart Visa ending in 8527', amount: '' },
+    ],
+  });
+  assert.equal(splitTender.length, 1);
+  assert.match(toPlain(splitTender)[0], /Split tender across 2 payment methods/);
+
+  // One tender: its amount IS the order total, so nothing is lost — stay quiet.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [{ brand: 'VISA', ending: 'ending in 1234', amount: '' }],
+  })), []);
+
+  // Amounts present — the healthy split-tender case, also quiet.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { brand: 'VISA', ending: 'ending in 1234', amount: '$20.00' },
+      { brand: 'GIFTCARD', ending: 'Gift Card', amount: '$6.84' },
+    ],
+  })), []);
+
+  // Partial extraction is not a silent loss: one known amount plus the order
+  // total gives the other, so this stays quiet too.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { brand: 'VISA', ending: 'ending in 1234', amount: '$200.51' },
+      { brand: '', ending: 'Ending in 2043', amount: '' },
+    ],
+  })), []);
+});
+
+test('readPaymentRowAmount reads the 2026 payment row (flex-auto moved off the amount)', () => {
+  const sandbox = loadDetailSandbox();
+  // `row` fakes an element: `.tr.flex-auto` via querySelector, `.tr` via querySelectorAll.
+  const row = (map) => ({
+    querySelector: (sel) => (map[sel] !== undefined ? { textContent: map[sel] } : null),
+    querySelectorAll: (sel) => (Array.isArray(map[sel]) ? map[sel] : map[sel] !== undefined
+      ? [{ textContent: map[sel] }] : []).map((v) => (typeof v === 'string' ? { textContent: v } : v)),
+  });
+
+  // Live markup, captured from an online order page 2026-08-11. The amount span carries
+  // `tr` only; `flex-auto` now sits on the sibling label div, so the old `.tr.flex-auto`
+  // matched nothing and every split-tender amount was dropped.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$107.75' })), '$107.75');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$8.00' })), '$8.00');
+
+  // Older pages put both classes on the amount — keep working.
+  assert.equal(
+    sandbox.readPaymentRowAmount(row({ '.tr.flex-auto': '$20.00', '.tr': '$20.00' })),
+    '$20.00');
+
+  // The specific selector wins when the two disagree.
+  assert.equal(
+    sandbox.readPaymentRowAmount(row({ '.tr.flex-auto': '$9.99', '.tr': '$1.00' })),
+    '$9.99');
+
+  // `.tr` is a text-align utility, so a row may hold one that is NOT the amount. Skip
+  // anything that does not look like money rather than exporting a label as a figure.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': ['Ending in 8527', '$75.29'] })),
+               '$75.29');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': 'Ending in 8527' })), '');
+
+
+  // Anchored, so text that merely CONTAINS a number is rejected.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '12.31.25' })), '');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$75.29 charged' })), '');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '3 hours or less' })), '');
+  // Real formats that must still pass.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$1,234.56' })), '$1,234.56');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '-$12.50' })), '-$12.50');
+  // In-store rows show no amount at all — empty, never undefined.
+  assert.equal(sandbox.readPaymentRowAmount(row({})), '');
+  assert.equal(sandbox.readPaymentRowAmount(null), '');
+});
+
+test('buildTenderLabel does not say the brand twice', () => {
+  const sandbox = loadDetailSandbox();
+  const label = sandbox.buildTenderLabel;
+
+  // Live case (order 200014610875731, 2026-08-11): the Walmart Cash row has the same
+  // text in img[alt] and in the card description, which used to render as
+  // "Walmart Cash Walmart Cash: $6.00".
+  assert.equal(label('Walmart Cash', 'Walmart Cash'), 'Walmart Cash');
+  // Description already carries the brand.
+  assert.equal(label('Visa', 'Walmart Visa ending in 8527'), 'Walmart Visa ending in 8527');
+  // Genuinely complementary — keep both.
+  assert.equal(label('Visa', 'Ending in 4122'), 'Visa Ending in 4122');
+  // Either side missing.
+  assert.equal(label('', 'Ending in 2043'), 'Ending in 2043');
+  assert.equal(label('GIFTCARD', ''), 'GIFTCARD');
+  assert.equal(label('', ''), '');
+});
+
 test('extractPrintItem parses the 2026 Walmart print view (Qty label, double-price string)', () => {
   const sandbox = loadDetailSandbox();
   const el = (text) => ({ textContent: text });

--- a/tests/content.detail.test.js
+++ b/tests/content.detail.test.js
@@ -116,6 +116,112 @@ test('computeExtractionWarnings trips on blank data and stays quiet on healthy d
   assert.equal(warnings.length, 3);
 });
 
+test('computeExtractionWarnings flags split tender with no per-tender amounts', () => {
+  const sandbox = loadDetailSandbox();
+  const base = { orderNumber: '582515916131486157579', orderTotal: '$204.26',
+    items: [{ productName: 'Fresh Strawberries, 1 lb Container', price: '$4.34' }] };
+
+  // A real in-store export (#20): both tenders named, neither carrying an
+  // amount, so paymentSplit is empty and the card was charged less than the
+  // order total. Nothing else in the payload says so.
+  const splitTender = sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { cardId: 'card-description-0', brand: '', ending: 'Ending in 2043', amount: '' },
+      { cardId: 'card-description-1', brand: '', ending: 'Walmart Visa ending in 8527', amount: '' },
+    ],
+  });
+  assert.equal(splitTender.length, 1);
+  assert.match(toPlain(splitTender)[0], /Split tender across 2 payment methods/);
+
+  // One tender: its amount IS the order total, so nothing is lost — stay quiet.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [{ brand: 'VISA', ending: 'ending in 1234', amount: '' }],
+  })), []);
+
+  // Amounts present — the healthy split-tender case, also quiet.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { brand: 'VISA', ending: 'ending in 1234', amount: '$20.00' },
+      { brand: 'GIFTCARD', ending: 'Gift Card', amount: '$6.84' },
+    ],
+  })), []);
+
+  // Partial extraction is not a silent loss: one known amount plus the order
+  // total gives the other, so this stays quiet too.
+  assert.deepEqual(toPlain(sandbox.computeExtractionWarnings({
+    ...base,
+    paymentMethodDetails: [
+      { brand: 'VISA', ending: 'ending in 1234', amount: '$200.51' },
+      { brand: '', ending: 'Ending in 2043', amount: '' },
+    ],
+  })), []);
+});
+
+test('readPaymentRowAmount reads the 2026 payment row (flex-auto moved off the amount)', () => {
+  const sandbox = loadDetailSandbox();
+  // `row` fakes an element: `.tr.flex-auto` via querySelector, `.tr` via querySelectorAll.
+  const row = (map) => ({
+    querySelector: (sel) => (map[sel] !== undefined ? { textContent: map[sel] } : null),
+    querySelectorAll: (sel) => (Array.isArray(map[sel]) ? map[sel] : map[sel] !== undefined
+      ? [{ textContent: map[sel] }] : []).map((v) => (typeof v === 'string' ? { textContent: v } : v)),
+  });
+
+  // Live markup, captured from an online order page 2026-08-11. The amount span carries
+  // `tr` only; `flex-auto` now sits on the sibling label div, so the old `.tr.flex-auto`
+  // matched nothing and every split-tender amount was dropped.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$107.75' })), '$107.75');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$8.00' })), '$8.00');
+
+  // Older pages put both classes on the amount — keep working.
+  assert.equal(
+    sandbox.readPaymentRowAmount(row({ '.tr.flex-auto': '$20.00', '.tr': '$20.00' })),
+    '$20.00');
+
+  // The specific selector wins when the two disagree.
+  assert.equal(
+    sandbox.readPaymentRowAmount(row({ '.tr.flex-auto': '$9.99', '.tr': '$1.00' })),
+    '$9.99');
+
+  // `.tr` is a text-align utility, so a row may hold one that is NOT the amount. Skip
+  // anything that does not look like money rather than exporting a label as a figure.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': ['Ending in 8527', '$75.29'] })),
+               '$75.29');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': 'Ending in 8527' })), '');
+
+
+  // Anchored, so text that merely CONTAINS a number is rejected.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '12.31.25' })), '');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$75.29 charged' })), '');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '3 hours or less' })), '');
+  // Real formats that must still pass.
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '$1,234.56' })), '$1,234.56');
+  assert.equal(sandbox.readPaymentRowAmount(row({ '.tr': '-$12.50' })), '-$12.50');
+  // In-store rows show no amount at all — empty, never undefined.
+  assert.equal(sandbox.readPaymentRowAmount(row({})), '');
+  assert.equal(sandbox.readPaymentRowAmount(null), '');
+});
+
+test('buildTenderLabel does not say the brand twice', () => {
+  const sandbox = loadDetailSandbox();
+  const label = sandbox.buildTenderLabel;
+
+  // Live case (order 200014610875731, 2026-08-11): the Walmart Cash row has the same
+  // text in img[alt] and in the card description, which used to render as
+  // "Walmart Cash Walmart Cash: $6.00".
+  assert.equal(label('Walmart Cash', 'Walmart Cash'), 'Walmart Cash');
+  // Description already carries the brand.
+  assert.equal(label('Visa', 'Walmart Visa ending in 8527'), 'Walmart Visa ending in 8527');
+  // Genuinely complementary — keep both.
+  assert.equal(label('Visa', 'Ending in 4122'), 'Visa Ending in 4122');
+  // Either side missing.
+  assert.equal(label('', 'Ending in 2043'), 'Ending in 2043');
+  assert.equal(label('GIFTCARD', ''), 'GIFTCARD');
+  assert.equal(label('', ''), '');
+});
+
 test('extractPrintItem parses the 2026 Walmart print view (Qty label, double-price string)', () => {
   const sandbox = loadDetailSandbox();
   const el = (text) => ({ textContent: text });


### PR DESCRIPTION
Fixes #20.

When part of an order is paid with Walmart Cash / rewards / a gift card, the card is charged **less** than the order total — and that smaller figure is the one a bank feed shows. Three things were wrong.

## 1. The amount selector is stale, so `paymentSplit` was always empty

`extractPaymentDetailsFromOrderPage()` reads each tender's amount from `.tr.flex-auto`. Walmart has since moved `flex-auto` off the amount and onto the label beside it, so that selector matches nothing:

```
div.flex.items-center.mb3
  div.flex.flex-column.flex-auto > span…b   "Ending in 4122"
  span.ld_Ee.ld_Ek.ld_Eh.tr      > div      "$31.54"
```

The **row** selector still matches (4 rows on a live page), so nothing looked broken — every method just came back with `amount: ''` and `buildPaymentSplit` dropped them all.

Extracted into `readPaymentRowAmount()`, which tries `.tr.flex-auto` first so older pages keep working, then falls back to `.tr` within the row. A candidate is accepted only when its **whole** text is an amount (anchored, not merely containing a number) so a date or version string can't slip in — `.tr` is a text-align utility, and a wrong amount is worse than none because it would flow into `paymentSplit` as fact.

Verified on live order pages, before → after:

| Order | before | after | order total |
|---|---|---|---:|
| 200014610875731 | `""` | `Walmart Cash: $6.00; Visa Ending in 4122: $31.54` | 37.54 |
| 200014001429225 | `""` | `Walmart Cash: $8.00; Visa Ending in 8527: $107.75` | 115.75 |
| 200013677297165 | `""` | `Walmart Cash: $4.00; Visa Ending in 8527: $49.08` | 53.08 |
| 200013039996427 | `""` | `Walmart Cash: $3.50; Visa Ending in 8527: $90.07` | 93.57 |

Each sums exactly to its order total.

## 2. The tender label said the brand twice

`brand` comes from the row's `img[alt]` and `ending` from the card description. For a card those differ usefully (`Visa` + `Ending in 4122`), but Walmart Cash and gift cards put the same text in both, giving `Walmart Cash Walmart Cash: $6.00`. Latent until now, because `paymentSplit` was never populated.

## 3. When no amount can be found, nothing said so

`computeExtractionWarnings()` covered items, order total and order number but not payment. It now flags 2+ methods with no per-tender amounts. Quiet for a single tender (its amount *is* the order total) and quiet when at least one amount is known (that plus the total gives the other).

Still needed after (1), because **in-store orders don't publish the split anywhere the extension can read**: the payment box names both tenders without figures, `.print-bill-payment-section` carries only subtotal/tax/total, the order page's `__NEXT_DATA__` has no order node, and "Print invoice" renders the real receipt — `WALMART REWARDS 3.75` / `WMP VISA CREDIT TEND 200.51` — as a 554×1961 **image** with zero text. Online orders are fixed; in-store ones are at least no longer silent.

## Tests

Three new cases in `content.detail.test.js`, mirrored into `tests-vitest/`. All three fail on `main` and pass with the change:

```
main:  238 pass / 6 fail
here:  241 pass / 3 fail
```

The 3 remaining failures are pre-existing in my environment (`Cannot find module 'exceljs'` — no `node_modules`); they fail identically on a clean checkout.

`readPaymentRowAmount` is covered for the live 2026 markup, the legacy markup, disagreement between the two, a `.tr` holding a label rather than an amount, thousands separators, negatives, and null/empty rows.

## Notes

- **`providers/walmart-ca.js` carries the same `.tr.flex-auto` selector** (line ~1132) and its own copy of `buildPaymentSplit`, so it's untouched here and likely has both bugs. I have no walmart.ca page to verify against and didn't want to change it blind.
- I couldn't run `wxt build` or `vitest run` locally (no pnpm). Both are syntax-level gates; I verified every shipped script with `node --check` and confirmed all 29 `tests-vitest/` files parse as ESM.